### PR TITLE
Handle command line arguments, create data packets with messages

### DIFF
--- a/swifi.tcl
+++ b/swifi.tcl
@@ -117,11 +117,11 @@ Agent/SWiFi set packet_size_ 1000
 
 set logfname [format "swifi_%s_%s.log" $func $mode]
 set logf [open $logfname w]
-Agent/SWiFi instproc recv {from rtt} {
+Agent/SWiFi instproc recv {from rtt data} {
 	global logf
         $self instvar node_
         puts $logf "Node [$node_ id] received reply from node $from\
-		with round-trip-time $rtt ms."
+		with round-trip-time $rtt ms and message $data."
 	flush $logf
 }
 


### PR DESCRIPTION
Now we use different command line arguments to let the tcl file act
accordingly. For example, `ns swifi.tcl rtt uplink` will run the
simulation to output rtt measurements in uplink mode. With no argument
specified, it defaults to run rtt measurements in downlink mode.
