### PR TITLE
allow Tk to use fontconfig fonts

### DIFF
--- a/install
+++ b/install
@@ -437,7 +437,7 @@ fi
 blame='Tk is not part of the ns project.  Please see www.Scriptics.com
 to see if they have a fix for your platform.'
 autoconf
-./configure --enable-gcc --disable-shared --disable-xft --disable-xss --prefix=$CUR_PATH || die "tk$TKVER configuration failed! Exiting ..."
+./configure --enable-gcc --enable-shared --enable-xft --enable-64bit --disable-rpath --disable-xss --prefix=$CUR_PATH || die "tk$TKVER configuration failed! Exiting ..."
 if make 
 then
 	echo "tk$TKVER build succeeded."

--- a/tk8.5.10/unix/Makefile.in
+++ b/tk8.5.10/unix/Makefile.in
@@ -722,7 +722,7 @@ install-binaries: $(TK_LIB_FILE) $(TK_STUB_LIB_FILE) wish@EXEEXT@
 	    fi
 	@echo "Installing $(LIB_FILE) to $(LIB_INSTALL_DIR)/"
 	@@INSTALL_LIB@
-	@chmod 555 "$(LIB_INSTALL_DIR)"/$(LIB_FILE)
+	@chmod 755 "$(LIB_INSTALL_DIR)"/$(LIB_FILE)
 	@echo "Installing wish@EXEEXT@ as $(BIN_INSTALL_DIR)/wish$(VERSION)@EXEEXT@"
 	@$(INSTALL_PROGRAM) wish@EXEEXT@ "$(BIN_INSTALL_DIR)"/wish$(VERSION)@EXEEXT@
 	@echo "Installing tkConfig.sh to $(CONFIG_INSTALL_DIR)/"

--- a/tk8.5.10/unix/configure.in
+++ b/tk8.5.10/unix/configure.in
@@ -528,8 +528,8 @@ if test $tk_aqua = no; then
 	XFT_LIBS=`xft-config --libs 2>/dev/null` || found_xft="no"
 	if test "$found_xft" = "no" ; then
 	    found_xft=yes
-	    XFT_CFLAGS=`pkg-config --cflags xft 2>/dev/null` || found_xft="no"
-	    XFT_LIBS=`pkg-config --libs xft 2>/dev/null` || found_xft="no"
+	    XFT_CFLAGS=`pkg-config --cflags xft freetype2 2>/dev/null` || found_xft="no"
+	    XFT_LIBS=`pkg-config --libs xft freetype2 2>/dev/null` || found_xft="no"
 	fi
 	AC_MSG_RESULT([$found_xft])
 	dnl make sure that compiling against Xft header file doesn't bomb

--- a/tk8.5.10/unix/tcl.m4
+++ b/tk8.5.10/unix/tcl.m4
@@ -1399,12 +1399,12 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
 	    # get rid of the warnings.
 	    #CFLAGS_OPTIMIZE="${CFLAGS_OPTIMIZE} -D__NO_STRING_INLINES -D__NO_MATH_INLINES"
 
-	    SHLIB_LD='${CC} -shared ${CFLAGS} ${LDFLAGS}'
+	    SHLIB_LD='${CC} -shared ${CFLAGS} ${LDFLAGS} -Wl,-soname,${@}'
 	    DL_OBJS="tclLoadDl.o"
 	    DL_LIBS="-ldl"
 	    LDFLAGS="$LDFLAGS -Wl,--export-dynamic"
 	    AS_IF([test $doRpath = yes], [
-		CC_SEARCH_FLAGS='-Wl,-rpath,${LIB_RUNTIME_DIR}'])
+		CC_SEARCH_FLAGS=''])
 	    LD_SEARCH_FLAGS=${CC_SEARCH_FLAGS}
 	    AS_IF([test "`uname -m`" = "alpha"], [CFLAGS="$CFLAGS -mieee"])
 	    AS_IF([test $do64bit = yes], [

--- a/tk8.5.10/unix/tkUnixRFont.c
+++ b/tk8.5.10/unix/tkUnixRFont.c
@@ -216,7 +216,7 @@ InitFont(
      */
 
     set = FcFontSort(0, pattern, FcTrue, NULL, &result);
-    if (!set) {
+    if (!set || set->nfont == 0) {
 	ckfree((char *)fontPtr);
 	return NULL;
     }


### PR DESCRIPTION
This is largely based on the patches from fedora packaging:
cf. https://pkgs.fedoraproject.org/cgit/rpms/tk.git/tree/

The primary reason for this commit is to make my Tcl/Tk based GUI application (most noticably gitk) can use modern system fonts. It should have no negative effects on our project itself. I've run several simple tests with swifi.tcl to validate that. Please help check.